### PR TITLE
Remove token data

### DIFF
--- a/api/workspace/collections/1.0/cloud/collection.tokenData.json
+++ b/api/workspace/collections/1.0/cloud/collection.tokenData.json
@@ -62,12 +62,22 @@
         {
           "hook": "rejectDuplicateTokenData"
         }
+      ],
+      "afterCreate": [
+        {
+          "hook": "removeOldTokenData"
+        }
       ]
     },
     "index": [
       {
         "keys": {
           "updatedAt": 1
+        }
+      },
+      {
+        "keys": {
+          "updatedAt": -1
         }
       }
     ]

--- a/api/workspace/hooks/removeOldTokenData.js
+++ b/api/workspace/hooks/removeOldTokenData.js
@@ -1,0 +1,44 @@
+/**
+ * Deletes tokenData records that are older than two days before the
+ * record that has been inserted
+ */
+
+const Model = require('@dadi/api').Model
+
+module.exports = function (obj, type, data) {
+  return deleteTokenData(obj, data).then(results => {
+    return obj
+  }).catch(err => {
+    return Promise.reject(err)
+  })
+}
+
+/**
+ * Query for deleting token data
+ *
+ * @param {object} obj - The token data from the CMC API
+ * @param {object} data - The hook data object
+ *
+ * @returns {Promise} - A an object containing details about deleted records
+ */
+const deleteTokenData = (obj, data) => {
+  // find timestamp for this time yesterday
+  let queryDate = new Date(obj.updatedAt * 1000)
+
+  // set the clock back two days
+  queryDate.setDate(queryDate.getDate() - 2)
+
+  let query = {
+    updatedAt: { '$lt': queryDate.valueOf() }
+  }
+
+  return new Promise((resolve, reject) => {
+    Model(data.collection).delete(query, (err, result) => {
+      if (err) {
+        return reject(err)
+      }
+
+      return resolve(result)
+    })
+  })
+}


### PR DESCRIPTION
this PR makes all fields in the tokenData collection mandatory, and adds a hook to remove records older than 2 days when a new one is added (as our graph is only a 24 hour view of the token performance)