### PR TITLE
Add protocol to api config

### DIFF
--- a/scripts/getTokenData.js
+++ b/scripts/getTokenData.js
@@ -17,7 +17,14 @@ const apiCredentials = {
   secret: webConfig.api.main.auth.secret
 }
 
+let protocol = webConfig.api.main.protocol
+
+if (protocol.indexOf(':') < 0) {
+  protocol = protocol + ':'
+}
+
 let apiOptions = {
+  protocol: protocol,
   hostname: webConfig.api.main.host,
   port: webConfig.api.main.port,
   method: 'POST',


### PR DESCRIPTION
The token data insert script doesn't supply the API protocol and fails if the wrong Nodejs http handler is used.

This PR adds the configured protocol to the token data insert request - requires additional config property in WEB if not already configured:

```
  "api": {
    "main": {
      "protocol": "https",
      "host": "127.0.0.1",
      "port": 8081,
      "auth": {
      }
    },
```